### PR TITLE
Tests for FIX: window.crypto is not available in worker

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/worker/worker.bundled.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 npm-debug.log
 .zuulrc
+test/worker/worker.bundled.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,9 @@ To unit test cuid in the browser version locally, run
 ```sh
 npm run test:browser
 ```
+
+To unit test cuid within a web worker in the browser version locally, run
+
+```sh
+npm run test:worker
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,6 +1268,12 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true
+    },
     "bin-v8-flags-filter": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bin-v8-flags-filter/-/bin-v8-flags-filter-1.2.0.tgz",
@@ -1920,6 +1926,12 @@
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -1999,6 +2011,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
     "create-ecdh": {
@@ -2387,6 +2405,26 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "ecstatic": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "dev": true,
+      "requires": {
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.61",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.61.tgz",
@@ -2734,6 +2772,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+      "dev": true
+    },
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -3001,6 +3045,32 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -3819,6 +3889,12 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "highlight-es": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.3.tgz",
@@ -3913,6 +3989,35 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "http-proxy": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-server": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.0.tgz",
+      "integrity": "sha512-imGLDSTT1BZ0QG1rBFnaZ6weK5jeisUnCxZQI1cpYTdz0luPUM5e3s+WU5zRWEkiI6DQxL2p54oeKrDlzO6bRw==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^1.0.3",
+        "colors": "^1.3.3",
+        "corser": "^2.0.1",
+        "ecstatic": "^3.3.2",
+        "http-proxy": "^1.17.0",
+        "opener": "^1.5.1",
+        "optimist": "~0.6.1",
+        "portfinder": "^1.0.20",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0"
       }
     },
     "https-browserify": {
@@ -5058,6 +5163,36 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -5308,6 +5443,49 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
       "dev": true
     },
+    "portfinder": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -5404,6 +5582,12 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz",
       "integrity": "sha1-p2pI4mEKGPl/o6K9UytoKs/4bFM=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
       "dev": true
     },
     "querystring": {
@@ -5638,6 +5822,12 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -5807,6 +5997,12 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "dev": true
     },
     "semver": {
       "version": "5.5.1",
@@ -6917,6 +7113,15 @@
       "integrity": "sha1-bmp6Gm6uuwHKPYsSrZaHJ56rpSQ=",
       "dev": true
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -7138,6 +7343,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browserify": "16.5.0",
     "eslint": "5.16.0",
     "eslint-plugin-testcafe": "0.2.1",
+    "http-server": "^0.12.0",
     "mkdirp": "0.5.1",
     "riteway": "6.1.1",
     "tape": "4.11.0",
@@ -54,8 +55,9 @@
     "build": "mkdirp dist && browserify index.js -s cuid -o dist/cuid.js && uglifyjs dist/cuid.js -c -m -o dist/cuid.min.js",
     "lint": "eslint index.js lib test",
     "prepare": "npm run build",
-    "test": "npm run -s lint && npm run -s test:server && npm run -s test:random && npm run -s test:browser",
+    "test": "npm run -s lint && npm run -s test:server && npm run -s test:random && npm run -s test:browser && npm run -s test:worker",
     "test:browser": "testcafe chrome ./test/browser.js",
+    "test:worker": "browserify test/worker/worker.js -s cuid -o test/worker/worker.bundled.js && http-server test/worker",
     "test:server": "tape -r babel-register -r babel-polyfill test/server.js",
     "test:random": "node -r babel-register -r babel-polyfill test/getRandomValue.test.js",
     "update": "updtr"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prepare": "npm run build",
     "test": "npm run -s lint && npm run -s test:server && npm run -s test:random && npm run -s test:browser && npm run -s test:worker",
     "test:browser": "testcafe chrome ./test/browser.js",
-    "test:worker": "browserify test/worker/worker.js -s cuid -o test/worker/worker.bundled.js && http-server test/worker",
+    "test:worker": "browserify ./test/worker/worker.js -s cuid -o ./test/worker/worker.bundled.js && testcafe chrome ./test/worker.js --app \"http-server ./test/worker -s\"",
     "test:server": "tape -r babel-register -r babel-polyfill test/server.js",
     "test:random": "node -r babel-register -r babel-polyfill test/getRandomValue.test.js",
     "update": "updtr"

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,9 @@
+import { Selector } from 'testcafe';
+
+fixture `cuid worker tests`
+    .page `http://localhost:8080`;
+
+test('Running tests within worker', async t => {
+    // check that there is no element with class "error"
+    await t.expect(Selector('.error').count).eql(0);
+});

--- a/test/worker/index.html
+++ b/test/worker/index.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="utf-8" />
-	<meta name="language" content="en" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Worker Test Page</title>
-	<script>
-		if (window.Worker) {
-			let worker = new Worker('worker.bundled.js');
-			worker.onmessage = function (event) {
-				document.body.textContent = event.data;
-			};
-			worker.postMessage(null);
-		}
-	</script>
+    <meta charset="utf-8" />
+    <meta name="language" content="en" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Worker Test Page</title>
+    <script>
+        if (window.Worker) {
+            let worker = new Worker('worker.bundled.js');
+            worker.onmessage = function (event) {
+                document.body.textContent = event.data;
+            };
+            worker.postMessage(null);
+        }
+    </script>
 </head>
 <body>
 </body>

--- a/test/worker/index.html
+++ b/test/worker/index.html
@@ -5,12 +5,23 @@
     <meta name="language" content="en" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Worker Test Page</title>
+    <style>
+        .ok { color: lime; }
+        .error { color: red; }
+    </style>
     <script>
         if (window.Worker) {
-            let worker = new Worker('worker.bundled.js');
+            var lineCounter = 0;
+
+            var worker = new Worker('./worker.bundled.js');
+
             worker.onmessage = function (event) {
-                document.body.textContent = event.data;
+                var line = document.createElement('div');
+                line.classList.add(event.data.error ? 'error' : 'ok');
+                line.textContent = ++lineCounter + '\t' + event.data.message;
+                document.body.appendChild(line)
             };
+
             worker.postMessage(null);
         }
     </script>

--- a/test/worker/index.html
+++ b/test/worker/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="language" content="en" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Worker Test Page</title>
+	<script>
+		if (window.Worker) {
+			let worker = new Worker('worker.bundled.js');
+			worker.onmessage = function (event) {
+				document.body.textContent = event.data;
+			};
+			worker.postMessage(null);
+		}
+	</script>
+</head>
+<body>
+</body>
+</html>

--- a/test/worker/worker.js
+++ b/test/worker/worker.js
@@ -1,5 +1,46 @@
+var assert = require('assert');
+
 var cuid = require('../..');
 
-self.onmessage = function () {
-    self.postMessage(cuid());
-};
+function ok (expression, message) {
+    try {
+        assert.ok(expression, message);
+
+        self.postMessage({
+            error: false,
+            message: message
+        });
+    } catch (error) {
+        self.postMessage({
+            error: true,
+            message: error.message
+        });
+    }
+}
+
+function run () {
+    // cuid()
+    ok(typeof cuid() === 'string', 'cuid() should return a string.');
+
+    // cuid.slug()
+    ok(typeof cuid.slug() === 'string', 'cuid.slug() should return a string.');
+
+    // cuid.isCuid()
+    var id = cuid();
+    ok(cuid.isCuid(id) === true, 'cuid.isCuid() should return true for a valid cuid.');
+    ok(cuid.isCuid(null) === false, 'cuid.isCuid() should return false for null.');
+    ok(cuid.isCuid(undefined) === false, 'cuid.isCuid() should return false for undefined.');
+    ok(cuid.isCuid('abcdefghijklmnopqrstuvwxy') === false, 'cuid.isCuid() should return false for a random string.');
+    ok(cuid.isCuid(1) === false, 'cuid.isCuid() should return false for numbers.');
+    ok(cuid.isCuid(NaN) === false, 'cuid.isCuid() should return false for NaN.');
+
+    // cuid.isSlug()
+    var slug = cuid.slug();
+    ok(cuid.isSlug(slug) === true, 'cuid.isSlug() should return true for a valid cuid slug.');
+    ok(cuid.isSlug(null) === false, 'cuid.isSlug() should return false for null.');
+    ok(cuid.isSlug(undefined) === false, 'cuid.isSlug() should return false for undefined.');
+    ok(cuid.isSlug(1) === false, 'cuid.isSlug() should return false for numbers.');
+    ok(cuid.isSlug(NaN) === false, 'cuid.isSlug() should return false for NaN.');
+}
+
+self.onmessage = run;

--- a/test/worker/worker.js
+++ b/test/worker/worker.js
@@ -1,5 +1,5 @@
 var cuid = require('../..');
 
 self.onmessage = function () {
-	self.postMessage(cuid());
+    self.postMessage(cuid());
 };

--- a/test/worker/worker.js
+++ b/test/worker/worker.js
@@ -1,0 +1,5 @@
+var cuid = require('../..');
+
+self.onmessage = function () {
+	self.postMessage(cuid());
+};


### PR DESCRIPTION
I added a build script "test:worker" that executes all existing tests (except from the collision tests) within a worker. Therefore, I serve a web page (test/worker/index.html) using the new dev dependency http-server.

The way of interacting with TestCafe may be a bit quirky - but it works. I counterchecked that by intentionally letting fail a test.